### PR TITLE
Optimize scorer

### DIFF
--- a/app.py
+++ b/app.py
@@ -35,7 +35,7 @@ def guess():
     if user_guess not in word_list and user_guess not in word_list:
         return jsonify({'feedback': f"'{user_guess}' is not in the vocabulary. Try a different word.", 'correct': False})
 
-    if scorer(user_guess, session['target_word'], word_list):
+    if scorer(user_guess, session['target_word']):
         feedback = f"🎉 Correct! The word was '{session['target_word']}'."
         session.pop('target_word')
         return jsonify({'feedback': feedback, 'correct': True})

--- a/score.py
+++ b/score.py
@@ -13,36 +13,17 @@ def cosine_similarity(vec1, vec2):
   return dp / (norm1 * norm2)
 
 
-def scorer(word1, target_word, word_list):
+def scorer(word1, target_word):
+    """Return True if the guess matches the target within tolerance."""
     try:
         vec1 = model[word1]
         vec_target = model[target_word]
-        
+
         similarity = cosine_similarity(vec1, vec_target)
         print(f"cosine similarity: {similarity:.5f}")
-        
-        #ranking alg, might be able to precompute this but i dont want to do that
-        similarities = []
-        for word in word_list:
-            try:
-                vec = model[word]
-                score = cosine_similarity(vec1, vec)
-                similarities.append((word, score))
-            except KeyError:
-                continue
-        
-        #reverse order
-        similarities.sort(key=lambda x: x[1], reverse=True)
-        
-        #rank of guessed word
-        rank = next((i + 1 for i, (word, _) in enumerate(similarities) if word == target_word), None)
-        print(f"{word1} is ranked #{rank} out of {len(similarities)}.")
-        
-        if 1 - config.WINNING_TOLERANCE <= similarity <= 1 + config.WINNING_TOLERANCE:
-            return True
-        else:
-            return False
-          
+
+        return 1 - config.WINNING_TOLERANCE <= similarity <= 1 + config.WINNING_TOLERANCE
+
     except KeyError:
         print(f"Error: '{word1}' is not in the vocabulary.")
         return False


### PR DESCRIPTION
## Summary
- refactor `scorer` to only compute guess-to-target similarity
- use the simplified scorer in `app.py`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_687a8889a5b4832cb2052dda97e86d4c