### PR TITLE
Fix redundant vocabulary check

### DIFF
--- a/app.py
+++ b/app.py
@@ -32,7 +32,7 @@ def guess():
     user_guess = data.get('guess', '').strip().lower()
 
     
-    if user_guess not in word_list and user_guess not in word_list:
+    if user_guess not in word_list:
         return jsonify({'feedback': f"'{user_guess}' is not in the vocabulary. Try a different word.", 'correct': False})
 
     if scorer(user_guess, session['target_word'], word_list):


### PR DESCRIPTION
## Summary
- simplify membership check when validating guesses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687a888a8164832cb34dc1c4ff89aff2