### PR TITLE
Add FLASK_DEBUG configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,8 @@ had no homework so remade contexto.
 find the mystery word by guessing words and having a stupid cosine similarity algorithm tell you how far away your guess is from the mystery word. 
 now with flask implementation!
 
+## Environment Variables
+
+- `FLASK_DEBUG` – Set to `True` to enable Flask debug mode. Defaults to `False`.
+
 ![image](https://github.com/user-attachments/assets/5898a2ad-587e-430a-b8c7-25f7d795f81f)

--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ from flask_session import Session
 from randomWord import randomWord
 from score import scorer
 import os
+import config
 
 app = Flask(__name__)
 
@@ -104,4 +105,5 @@ def generate_rankings(target_word, vocab):
     return {word: rank + 1 for rank, (word, _) in enumerate(sorted_words)}
 
 if __name__ == "__main__":
-    app.run(debug=True) #get rid of this if i decide to do anything with this later
+    # The debug flag is controlled via the FLASK_DEBUG environment variable.
+    app.run(debug=config.FLASK_DEBUG)

--- a/config.py
+++ b/config.py
@@ -1,1 +1,7 @@
+import os
+
 WINNING_TOLERANCE = .0001
+
+# Determines if Flask should run in debug mode. Defaults to False if the
+# environment variable is not set.
+FLASK_DEBUG = os.getenv("FLASK_DEBUG", "False").lower() in ("1", "true", "yes")


### PR DESCRIPTION
## Summary
- configure Flask debug flag via `FLASK_DEBUG` environment variable
- respect this flag when running the app
- document the new variable in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_687a889abbac832c8aa94ec69148898b