### PR TITLE
Add SECRET_KEY configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,10 @@ had no homework so remade contexto.
 find the mystery word by guessing words and having a stupid cosine similarity algorithm tell you how far away your guess is from the mystery word. 
 now with flask implementation!
 
+## Environment
+
+Set the `SECRET_KEY` environment variable to a strong value when running in
+production. The application falls back to `"change-me"` if no value is
+provided.
+
 ![image](https://github.com/user-attachments/assets/5898a2ad-587e-430a-b8c7-25f7d795f81f)

--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ from score import scorer
 import os
 
 app = Flask(__name__)
+app.config['SECRET_KEY'] = os.getenv('SECRET_KEY', 'change-me')
 
 
 app.config['SESSION_TYPE'] = 'filesystem'


### PR DESCRIPTION
## Summary
- pull SECRET_KEY from environment with fallback
- document SECRET_KEY usage

## Testing
- `python -m py_compile app.py score.py randomWord.py config.py`

------
https://chatgpt.com/codex/tasks/task_b_687a88ab5670832cb42dea4452a78fc9