### PR TITLE
Add pytest tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,13 @@ find the mystery word by guessing words and having a stupid cosine similarity al
 now with flask implementation!
 
 ![image](https://github.com/user-attachments/assets/5898a2ad-587e-430a-b8c7-25f7d795f81f)
+
+## Running Tests
+
+This project uses `pytest` for its test suite. After installing the required dependencies, run:
+
+```bash
+pytest
+```
+
+The tests live in the `tests/` directory and cover the basic game flow and utility endpoints.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,49 @@
+import json
+import pytest
+
+import app
+
+@pytest.fixture
+def client():
+    app.app.config['TESTING'] = True
+    with app.app.test_client() as client:
+        yield client
+
+def setup_patches(monkeypatch):
+    monkeypatch.setattr(app, 'randomWord', lambda: 'apple')
+    monkeypatch.setattr(app, 'generate_rankings', lambda target, vocab: {'apple': 1, 'orange': 2, 'cat': 3})
+    monkeypatch.setattr(app, 'scorer', lambda word, target, vocab: word == target)
+
+
+def test_reset_game(client, monkeypatch):
+    setup_patches(monkeypatch)
+    response = client.get('/')
+    assert response.status_code == 200
+    with client.session_transaction() as sess:
+        assert sess['target_word'] == 'apple'
+        assert sess['guesses'] == []
+        assert sess['rankings']['apple'] == 1
+
+
+def test_valid_guess(client, monkeypatch):
+    setup_patches(monkeypatch)
+    client.get('/')  # start game
+    response = client.post('/guess', json={'guess': 'apple'})
+    data = response.get_json()
+    assert data['correct'] is True
+    assert 'apple' in data['feedback']
+    with client.session_transaction() as sess:
+        assert 'target_word' not in sess
+
+
+def test_hint_and_giveup(client, monkeypatch):
+    setup_patches(monkeypatch)
+    client.get('/')
+    hint_resp = client.get('/hint')
+    hint_data = hint_resp.get_json()
+    assert hint_resp.status_code == 200
+    assert hint_data['hints'][0]['word'] == 'orange'
+    giveup_resp = client.get('/giveup')
+    giveup_data = giveup_resp.get_json()
+    assert giveup_resp.status_code == 200
+    assert giveup_data['answer'] == 'apple'


### PR DESCRIPTION
## Summary
- add pytest-based tests for core game flow
- document pytest usage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_687a88b5cbcc832ca16378444c862e1f